### PR TITLE
VMAlert: Infinite sync loop in ArgoCD when `Replace=true`

### DIFF
--- a/kubernetes/argocd/05_monitoring/victoria-metrics.yaml
+++ b/kubernetes/argocd/05_monitoring/victoria-metrics.yaml
@@ -17,4 +17,4 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - Replace=true
+      - ServerSideApply=true

--- a/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
+++ b/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
@@ -128,7 +128,7 @@ helmCharts:
           enabled: true
           spec:
             externalLabels:
-              dummy: dummy #
+              dummy: dummy # FIX: ArgoCD infinite sync loop when `Replace=true`
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
+++ b/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
@@ -127,6 +127,8 @@ helmCharts:
         vmalert:
           enabled: true
           spec:
+            externalLabels:
+              dummy: dummy #
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
+++ b/kubernetes/cluster/monitoring/victoria-metrics/monitoring/kustomization.yaml
@@ -127,8 +127,6 @@ helmCharts:
         vmalert:
           enabled: true
           spec:
-            externalLabels:
-              dummy: dummy # FIX: ArgoCD infinite sync loop when `Replace=true`
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
When `Replace=true` externalLabels in VMAlert are set to {} in desired manifest and completely lacking in target manifest. This causes infinite loop.
However adding dummy tags causes the TooHighChurnRate24h and TooManyLogs alerts.
Need a better fix