### PR TITLE
[rollback] Jellyfin `10.8.13`

### DIFF
--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -42,7 +42,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: jellyfin
-          image: jellyfin/jellyfin:10.9.1
+          image: jellyfin/jellyfin:10.8.13
           resources:
             requests:
               memory: 1000Mi


### PR DESCRIPTION
Rolling back from `10.9.x` due to severe performance degradation and multiple `database locked` errors.