### PR TITLE
[fix] `Jellyfin` move from NFS to iSCSI

### DIFF
--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -69,6 +69,7 @@ spec:
               mountPath: /config
             - name: jellyfin-data
               mountPath: /config/data
+              subPath: data
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,8 +67,8 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
-            # - name: jellyfin-data
-            #   mountPath: /media/test
+            - name: jellyfin-data
+              mountPath: /media/test
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -77,14 +77,13 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
-        # - name: jellyfin-data
-        #   iscsi:
-        #     targetPortal: 192.168.1.222:3260
-        #     #portals: ['192.168.1.222:3260']
-        #     iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
-        #     lun: 0
-        #     fsType: ext4
-        #     readOnly: false
+        - name: jellyfin-data
+          iscsi:
+            targetPortal: 192.168.1.222
+            iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin
+            lun: 0
+            fsType: ext4
+            readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,9 +67,11 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
-            - name: jellyfin-data
-              mountPath: /config/data
-              subPath: data
+            - name: jellyfin-config-iscsi
+              mountPath: /media/temp
+            # - name: jellyfin-data
+            #   mountPath: /config/data
+            #   subPath: data
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -78,14 +80,17 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
-        - name: jellyfin-data
-          # Ref: https://github.com/kubernetes/examples/blob/master/volumes/iscsi/README.md
-          iscsi:
-            targetPortal: 192.168.1.222
-            iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin
-            lun: 0
-            fsType: ext4
-            readOnly: false
+        - name: jellyfin-config-iscsi
+          persistentVolumeClaim:
+            claimName: jellyfin-config-iscsi
+        # - name: jellyfin-data
+        #   # Ref: https://github.com/kubernetes/examples/blob/master/volumes/iscsi/README.md
+        #   iscsi:
+        #     targetPortal: 192.168.1.222
+        #     iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin
+        #     lun: 0
+        #     fsType: ext4
+        #     readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -68,7 +68,7 @@ spec:
             - name: jellyfin-config
               mountPath: /config
             - name: jellyfin-data
-              mountPath: /media/test
+              mountPath: /config/data
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,6 +67,8 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
+            - name: jellyfin-data
+              mountPath: /media/test
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -75,6 +77,14 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
+        - name: jellyfin-data
+          iscsi:
+            targetPortal: nas.brhd.io:3260
+            # portals: ['10.0.2.16:3260', '10.0.2.17:3260']
+            iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
+            lun: 0
+            fsType: ext4
+            readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -79,6 +79,7 @@ spec:
           persistentVolumeClaim:
             claimName: jellyfin-config
         - name: jellyfin-data
+          # Ref: https://github.com/kubernetes/examples/blob/master/volumes/iscsi/README.md
           iscsi:
             targetPortal: 192.168.1.222
             iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -79,8 +79,8 @@ spec:
             claimName: jellyfin-config
         - name: jellyfin-data
           iscsi:
-            targetPortal: nas.brhd.io:3260
-            portals: ['nas.brhd.io:3260']
+            targetPortal: 192.168.1.222:3260
+            #portals: ['192.168.1.222:3260']
             iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
             lun: 0
             fsType: ext4

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,8 +67,8 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
-            - name: jellyfin-data
-              mountPath: /media/test
+            # - name: jellyfin-data
+            #   mountPath: /media/test
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -77,14 +77,14 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
-        - name: jellyfin-data
-          iscsi:
-            targetPortal: 192.168.1.222:3260
-            #portals: ['192.168.1.222:3260']
-            iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
-            lun: 0
-            fsType: ext4
-            readOnly: false
+        # - name: jellyfin-data
+        #   iscsi:
+        #     targetPortal: 192.168.1.222:3260
+        #     #portals: ['192.168.1.222:3260']
+        #     iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
+        #     lun: 0
+        #     fsType: ext4
+        #     readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,8 +67,8 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
-            - name: jellyfin-data
-              mountPath: /media/test
+            # - name: jellyfin-data
+            #   mountPath: /media/test
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -77,14 +77,14 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
-        - name: jellyfin-data
-          iscsi:
-            targetPortal: 192.168.1.222:3260
-            #portals: ['192.168.1.222:3260']
-            iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
-            lun: 0
-            fsType: ext4
-            readOnly: true
+        # - name: jellyfin-data
+        #   iscsi:
+        #     targetPortal: 192.168.1.222:3260
+        #     #portals: ['192.168.1.222:3260']
+        #     iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
+        #     lun: 0
+        #     fsType: ext4
+        #     readOnly: true
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -83,7 +83,7 @@ spec:
             #portals: ['192.168.1.222:3260']
             iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
             lun: 0
-            fsType: ext4
+            fsType: ext2
             readOnly: false
         - name: jellyfin-cache
           emptyDir: {}

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -65,32 +65,16 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 120
           volumeMounts:
-            - name: jellyfin-config
-              mountPath: /config
             - name: jellyfin-config-iscsi
-              mountPath: /media/temp
-            # - name: jellyfin-data
-            #   mountPath: /config/data
-            #   subPath: data
+              mountPath: /config
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
               mountPath: /downloads
       volumes:
-        - name: jellyfin-config
-          persistentVolumeClaim:
-            claimName: jellyfin-config
         - name: jellyfin-config-iscsi
           persistentVolumeClaim:
             claimName: jellyfin-config-iscsi
-        # - name: jellyfin-data
-        #   # Ref: https://github.com/kubernetes/examples/blob/master/volumes/iscsi/README.md
-        #   iscsi:
-        #     targetPortal: 192.168.1.222
-        #     iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin
-        #     lun: 0
-        #     fsType: ext4
-        #     readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -67,8 +67,8 @@ spec:
           volumeMounts:
             - name: jellyfin-config
               mountPath: /config
-            # - name: jellyfin-data
-            #   mountPath: /media/test
+            - name: jellyfin-data
+              mountPath: /media/test
             - name: jellyfin-cache
               mountPath: /cache
             - name: downloads
@@ -77,14 +77,14 @@ spec:
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config
-        # - name: jellyfin-data
-        #   iscsi:
-        #     targetPortal: 192.168.1.222:3260
-        #     #portals: ['192.168.1.222:3260']
-        #     iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
-        #     lun: 0
-        #     fsType: ext4
-        #     readOnly: true
+        - name: jellyfin-data
+          iscsi:
+            targetPortal: 192.168.1.222:3260
+            #portals: ['192.168.1.222:3260']
+            iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
+            lun: 0
+            fsType: ext4
+            readOnly: false
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -83,8 +83,8 @@ spec:
             #portals: ['192.168.1.222:3260']
             iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
             lun: 0
-            fsType: ext2
-            readOnly: false
+            fsType: ext4
+            readOnly: true
         - name: jellyfin-cache
           emptyDir: {}
         - name: downloads

--- a/kubernetes/cluster/media/jellyfin/jellyfin.yaml
+++ b/kubernetes/cluster/media/jellyfin/jellyfin.yaml
@@ -80,7 +80,7 @@ spec:
         - name: jellyfin-data
           iscsi:
             targetPortal: nas.brhd.io:3260
-            # portals: ['10.0.2.16:3260', '10.0.2.17:3260']
+            portals: ['nas.brhd.io:3260']
             iqn: iqn.2005-10.org.freenas.ctl:k8s-jellyfin
             lun: 0
             fsType: ext4

--- a/kubernetes/cluster/media/jellyfin/volumes.yaml
+++ b/kubernetes/cluster/media/jellyfin/volumes.yaml
@@ -14,3 +14,43 @@ spec:
   resources:
     requests:
       storage: 50G
+---
+# Jellyfin -- Config
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jellyfin-config-iscsi
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      storage.target: jellyfin-config-iscsi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jellyfin-config-iscsi
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin
+    storage.target: jellyfin-config-iscsi
+spec:
+  accessModes:
+    - ReadWriteOnce
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  capacity:
+    storage: 10Gi
+  iscsi:
+    targetPortal: 192.168.1.222
+    iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin
+    lun: 0
+    fsType: ext4
+    readOnly: false

--- a/kubernetes/cluster/media/jellyfin/volumes.yaml
+++ b/kubernetes/cluster/media/jellyfin/volumes.yaml
@@ -3,22 +3,6 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: jellyfin-config
-  namespace: media
-  labels:
-    app.kubernetes.io/name: jellyfin
-spec:
-  accessModes:
-  - ReadWriteOnce
-  storageClassName: nfs-subdir
-  resources:
-    requests:
-      storage: 50G
----
-# Jellyfin -- Config
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
   name: jellyfin-config-iscsi
   namespace: media
   labels:
@@ -48,6 +32,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   capacity:
     storage: 10Gi
+  # Ref: https://github.com/kubernetes/examples/blob/master/volumes/iscsi/README.md
   iscsi:
     targetPortal: 192.168.1.222
     iqn: iqn.2005-10.org.freenas.ctl:k8s.jellyfin


### PR DESCRIPTION
Trying iSCSI instead of NFS for the SQLite based workload to see if it helps with the random freezes of the pod. If this is stable, need to explore the solution to properly back PVs and potentially create an iSCSI storage class.