### PR TITLE
[feature] Copy `qbitmanage` config from mounted ConfigMap to file

### DIFF
--- a/kubernetes/cluster/media/qbitmanage/config/config.yml
+++ b/kubernetes/cluster/media/qbitmanage/config/config.yml
@@ -1,5 +1,3 @@
-# NOTE: this config is currently copied manually to the PV location
-# TODO: automate the deployment of this config
 commands:
   dry_run: false
   cross_seed: false
@@ -41,23 +39,22 @@ cat:
   lidarr: /downloads/zzz/complete/_lidarr
   stash: /downloads/misc
 
-# replace (*) with full names from url
 tracker:
   t-ru:
     tag:
       - rutracker
       - public
-  t**********h|t*****reload:
+  torrentleech|tleechreload:
     tag:
-      - t**********h
+      - torrentleech
       - private
-  h****s:
+  hdbits:
     tag:
-      - h****s
+      - hdbits
       - private
-  t***********c:
+  trancetraffic:
     tag:
-    - t***********c
+    - trancetraffic
     - private
   racingfor:
     tag: rfm

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: media
 resources:
   - qbitmanage.yaml
   - volumes.yaml

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -7,5 +7,5 @@ configMapGenerator:
   - name: qbitmanage-config-yml
     files:
     - config/config.yml
-generatorOptions:
-  disableNameSuffixHash: true
+# generatorOptions:
+#   disableNameSuffixHash: true

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 configMapGenerator:
   - name: qbitmanage-config-yml
     files:
-    - config/cbnfig.yml
+    - config/config.yml

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 resources:
   - qbitmanage.yaml
   - volumes.yaml
+configMapGenerator:
+  - name: qbitmanage-config-yml
+    files:
+    - config/cbnfig.yml

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -8,5 +8,3 @@ configMapGenerator:
   - name: qbitmanage-config-yml
     files:
     - config/config.yml
-# generatorOptions:
-#   disableNameSuffixHash: true

--- a/kubernetes/cluster/media/qbitmanage/kustomization.yaml
+++ b/kubernetes/cluster/media/qbitmanage/kustomization.yaml
@@ -7,3 +7,5 @@ configMapGenerator:
   - name: qbitmanage-config-yml
     files:
     - config/config.yml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -50,6 +50,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: qbitmanage-init
           resources: {}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           volumeMounts:
             - name: qbitmanage-config
               mountPath: /config 

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -43,7 +43,7 @@ spec:
         - args:
             - '-v'
             - /config.yml
-            - /config/config-test.yml
+            - /config/config.yml
           command:
             - cp
           image: busybox:latest

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -39,6 +39,23 @@ spec:
               mountPath: /downloads
             - name: qbitmanage-config
               mountPath: /config
+      initContainers:
+        - args:
+            - '-v'
+            - /config.yml
+            - /config/config-test.yml
+          command:
+            - cp
+          image: busybox:latest
+          imagePullPolicy: IfNotPresent
+          name: qbitmanage-init
+          resources: {}
+          volumeMounts:
+            - name: qbitmanage-config
+              mountPath: /config 
+            - name: qbitmanage-config-yml
+              mountPath: /config.yml
+              subPath: config.yml
       volumes:
         - name: downloads
           persistentVolumeClaim:
@@ -46,3 +63,6 @@ spec:
         - name: qbitmanage-config
           persistentVolumeClaim:
             claimName: qbitmanage-config
+        - name: qbitmanage-config-yml
+          configMap:
+            name: qbitmanage-config-yml

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -54,6 +54,7 @@ spec:
             - name: qbitmanage-config
               mountPath: /config 
             - name: qbitmanage-config-yml
+              defaultMode: 420
               mountPath: /config.yml
               subPath: config.yml
       volumes:

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -57,7 +57,6 @@ spec:
             - name: qbitmanage-config
               mountPath: /config 
             - name: qbitmanage-config-yml
-              # defaultMode: 420
               mountPath: /config.yml
               subPath: config.yml
       volumes:

--- a/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
+++ b/kubernetes/cluster/media/qbitmanage/qbitmanage.yaml
@@ -54,7 +54,7 @@ spec:
             - name: qbitmanage-config
               mountPath: /config 
             - name: qbitmanage-config-yml
-              defaultMode: 420
+              # defaultMode: 420
               mountPath: /config.yml
               subPath: config.yml
       volumes:


### PR DESCRIPTION
qBitmanage requires write permissions on the config file hence using a read-only ConfigMap approach does not work.