### PR TITLE
[chore] Update OpenClaw doctor config

### DIFF
--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -310,7 +310,7 @@
         "enabled": false
       },
       "karakeep": {
-        "enabled": false
+        "enabled": true
       },
       "mcporter": {
         "enabled": false
@@ -319,6 +319,9 @@
         "enabled": false
       },
       "nano-pdf": {
+        "enabled": false
+      },
+      "notion": {
         "enabled": false
       },
       "obsidian": {
@@ -367,7 +370,7 @@
         "enabled": false
       },
       "vikunja": {
-        "enabled": false
+        "enabled": true
       },
       "voice-call": {
         "enabled": false

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -34,17 +34,20 @@
           {
             "id": "gemma4:31b-cloud",
             "name": "gemma4:31b-cloud",
-            "reasoning": true
+            "reasoning": true,
+            "input": ["text"]
           },
           {
             "id": "minimax-m2.7:cloud",
             "name": "minimax-m2.7:cloud",
-            "reasoning": true
+            "reasoning": true,
+            "input": ["text"]
           },
           {
             "id": "kimi-k2.6:cloud",
             "name": "kimi-k2.6:cloud",
-            "reasoning": true
+            "reasoning": true,
+            "input": ["text"]
           }
         ]
       }
@@ -167,7 +170,8 @@
       "browser",
       "memory-wiki",
       "codex",
-      "discord"
+      "discord",
+      "openai"
     ],
     "deny": [],
     "entries": {
@@ -179,7 +183,8 @@
           "dreaming": {
             "enabled": true
           }
-        }
+        },
+        "enabled": true
       },
       "active-memory": {
         "enabled": true,
@@ -235,16 +240,146 @@
             "createDashboards": false
           }
         }
+      },
+      "openai": {
+        "enabled": true
+      },
+      "ollama": {
+        "enabled": true
+      },
+      "browser": {
+        "enabled": true
       }
-    }
+    },
+    "bundledDiscovery": "compat"
   },
-
   "skills": {
     "load": {
       "extraDirs": ["/app/custom/skills"]
+    },
+    "entries": {
+      "1password": {
+        "enabled": false
+      },
+      "apple-notes": {
+        "enabled": false
+      },
+      "apple-reminders": {
+        "enabled": false
+      },
+      "bear-notes": {
+        "enabled": false
+      },
+      "blogwatcher": {
+        "enabled": false
+      },
+      "blucli": {
+        "enabled": false
+      },
+      "camsnap": {
+        "enabled": false
+      },
+      "clawhub": {
+        "enabled": false
+      },
+      "coding-agent": {
+        "enabled": false
+      },
+      "discord": {
+        "enabled": false
+      },
+      "eightctl": {
+        "enabled": false
+      },
+      "gemini": {
+        "enabled": false
+      },
+      "gifgrep": {
+        "enabled": false
+      },
+      "gog": {
+        "enabled": false
+      },
+      "goplaces": {
+        "enabled": false
+      },
+      "himalaya": {
+        "enabled": false
+      },
+      "imsg": {
+        "enabled": false
+      },
+      "karakeep": {
+        "enabled": false
+      },
+      "mcporter": {
+        "enabled": false
+      },
+      "model-usage": {
+        "enabled": false
+      },
+      "nano-pdf": {
+        "enabled": false
+      },
+      "obsidian": {
+        "enabled": false
+      },
+      "openai-whisper": {
+        "enabled": false
+      },
+      "openai-whisper-api": {
+        "enabled": false
+      },
+      "openhue": {
+        "enabled": false
+      },
+      "oracle": {
+        "enabled": false
+      },
+      "ordercli": {
+        "enabled": false
+      },
+      "peekaboo": {
+        "enabled": false
+      },
+      "sag": {
+        "enabled": false
+      },
+      "sherpa-onnx-tts": {
+        "enabled": false
+      },
+      "songsee": {
+        "enabled": false
+      },
+      "sonoscli": {
+        "enabled": false
+      },
+      "spotify-player": {
+        "enabled": false
+      },
+      "things-mac": {
+        "enabled": false
+      },
+      "tmux": {
+        "enabled": false
+      },
+      "trello": {
+        "enabled": false
+      },
+      "vikunja": {
+        "enabled": false
+      },
+      "voice-call": {
+        "enabled": false
+      },
+      "wacli": {
+        "enabled": false
+      },
+      "xurl": {
+        "enabled": false
+      }
     }
   },
-
   "tools": {
     "deny": [
       "canvas"
@@ -293,7 +428,8 @@
               "users": ["${DISCORD_OWNER_ID}"]
             }
           }
-        }
+        },
+        "default": {"groupPolicy": "allowlist"}
       }
     },
     "whatsapp": {
@@ -335,13 +471,13 @@
 
   "auth": {
     "profiles": {
-      "openai-codex:default": {
-        "provider": "openai-codex",
+      "openai:default": {
+        "provider": "openai",
         "mode": "oauth"
       }
     },
     "order": {
-      "openai-codex": ["openai-codex:default"]
+      "openai": ["openai:default"]
     }
   },
 

--- a/kubernetes/cluster/ai/openclaw/openclaw.yaml
+++ b/kubernetes/cluster/ai/openclaw/openclaw.yaml
@@ -109,11 +109,11 @@ spec:
                 name: openclaw
           resources:
             requests:
-              memory: 1Gi
+              memory: 2.5Gi
               cpu: 150m
             limits:
               memory: 8Gi
-              cpu: 1000m
+              cpu: 2000m
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
<!--- Provide a general summary of the changes in the Title above -->

## Description
Updates the OpenClaw deployment configuration for the current doctor/runtime setup:

- expands OpenClaw provider, plugin, bundled discovery, and skill configuration
- enables the OpenAI, Ollama, browser, memory, and Vikunja-related runtime entries needed by the config
- switches auth config from the old `openai-codex` provider key to `openai`
- adds explicit text-input metadata to the configured Ollama cloud models
- increases the OpenClaw gateway resources from `1Gi` to `2.5Gi` memory request and from `1000m` to `2000m` CPU limit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore (maintenance, documentation improvement, version upgrade)

## Operational impact
This will roll the OpenClaw Deployment after ArgoCD applies the updated ConfigMap and resource settings. The scheduler must have room for the higher `2.5Gi` memory request; no new service, hostname, secret, or Homer dashboard entry is introduced.

## Validation
- Inspected the PR diff for `kubernetes/cluster/ai/openclaw/config/openclaw.json` and `kubernetes/cluster/ai/openclaw/openclaw.yaml`.
- Ran `git diff --check origin/main...FETCH_HEAD` with no whitespace errors.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask your fellow team members. -->
- [x] PR title follows naming standards: [feature|bugfix|chore] Short description of the change
- [ ] PR introduces a new service and requires updates to the README.md
- [ ] README.md is updated with the following:
  - [ ] service name
  - [ ] short description
  - [ ] repository link
  - [ ] documentation link
  - [ ] docker or helm link
  - [ ] docker or helm documentation
- [ ] `Homer` dashboard has been updated