### PR TITLE
chore(deps): update ghcr.io/maxim-mityutko/openclaw-docker docker tag to v2026.6.8.0

### DIFF
--- a/kubernetes/cluster/ai/openclaw/openclaw.yaml
+++ b/kubernetes/cluster/ai/openclaw/openclaw.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: gateway
           # Using custom image with baked in dependencies
-          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.6.1.1
+          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.6.8.0
           command:
             - node
             - /app/dist/index.js


### PR DESCRIPTION
## Summary

Renovate updates the custom OpenClaw image used by the in-cluster OpenClaw deployment:

| Package | Update | Change |
|---|---|---|
| [`ghcr.io/maxim-mityutko/openclaw-docker`](https://github.com/maxim-mityutko/openclaw-docker) | patch | `v2026.6.1.1` -> `v2026.6.8.0` |

The wrapper image changelog only points to the Docker image compare, so the useful review context is the upstream OpenClaw release range. The stable upstream releases covered after the current base are:

- [`openclaw/openclaw v2026.6.5`](https://github.com/openclaw/openclaw/releases/tag/v2026.6.5)
- [`openclaw/openclaw v2026.6.6`](https://github.com/openclaw/openclaw/releases/tag/v2026.6.6)
- [`openclaw/openclaw v2026.6.8`](https://github.com/openclaw/openclaw/releases/tag/v2026.6.8)

## Upstream release notes

### v2026.6.8

- Richer Telegram and WhatsApp delivery: Telegram structured text, tables, lists, expandable blockquotes, preserved line breaks, CLI-backed replies, and WhatsApp ACP binding support.
- More reliable agent runs: account-scoped DM sends, generated media completions, auto-reply message-tool final replies, reset archive fallback reads, restart shutdown aborts, yielded subagent pauses, and session identity prompts.
- Safer model/provider routing: GLM-5.2 and Claude Haiku 4.5 catalog support, normalized provider IDs, managed SecretRef auth, bounded model browsing, and safer OpenAI/Anthropic tool-schema recovery.
- `/usage` and reply payload hooks gain a native footer renderer, default templates, fixed-decimal formatting, credential-aware limits, and template warnings.
- Key-free web-search providers such as Parallel Free, DuckDuckGo, Ollama, and Codex Hosted Search remain explicit opt-ins instead of automatic fallbacks.
- UI/session stability: collapsed workspace files by default, WebChat backscroll during streaming, desktop session picker fixes, reset argument preservation, and stale foreground iOS Gateway reconnects.
- Memory/state resilience: oversized OpenAI embedding batches split before 431s, QMD search remains available in transient mode, SQLite avoids WAL on NFS volumes, and full reindexes preserve rollback/cache recovery.
- Dependency/runtime fix: Hono updated to `4.12.25` for the published OpenClaw and ACPX packages.

### v2026.6.6

- Security boundary hardening across transcript, sandbox, MCP, browser, channel, and exec-approval paths; unsafe access, approval timeouts, and malformed boundary input fail closed.
- Telegram delivery fixes for account-scoped topics, streamed text through tool calls, coherent callbacks/draft chunks, and unauthorized DM cache/prompt isolation.
- iMessage reliability improvements for always-on inbound recovery, durable echo markers, block streaming, idle approval discovery, and outbound transport after restarts/idle periods.
- Browser and MCP connectivity improvements for existing browser sessions, CDP/WebSocket discovery, default-profile URLs, OAuth/SSE transport, and tool schemas.
- Faster first replies: Control UI startup avoids broad model loading; cached metadata, lazy slash commands, and first-event tracing expose slow initial replies.
- Provider support additions: OpenRouter OAuth, Claude Fable 5, correct Codex compaction ownership, local-model execution, normalized tool progress, and Gemma 4 reasoning replay.
- Runtime fixes around stale approvals, reply-queue identity, Codex compaction, provider-failure lifecycle state, Cron cancellation, Gateway config/auth, package Gateway restarts, and plugin convergence repair.

### v2026.6.5

- Safer channel output: QQBot strips model reasoning/thinking scaffolding before native delivery.
- MCP tool-result normalization prevents `resource_link`, audio, malformed image, and future non-text result blocks from poisoning provider history or causing Anthropic 400s.
- Anthropic extended-thinking recovery now handles prompt-cache expiry and early-signature failures through the existing retry path after restarts.
- Parallel web search is bundled as a first-class provider with API-key discovery, guarded endpoint handling, cache-safe session IDs, onboarding, and docs.
- Matrix and Google Vertex reliability: Matrix voice notes/threaded conversations preserve context; Vertex ADC models regain static catalog and runtime resolution.
- Safer upgrades/restarts: legacy cron JSON stores migrate before runtime, service env placeholders stop masking secrets, and macOS avoids unnecessary direct-Gateway reconnect churn.
- Additional fixes cover `sessions_send` explicit `sessionKey`, model/provider resolution, WhatsApp/Mattermost/Feishu/voice-call channel behavior, and MCP redirect/config bounds.

## Operational impact

- No manifest shape change beyond the OpenClaw image tag in `kubernetes/cluster/ai/openclaw/openclaw.yaml`.
- This update is mostly runtime behavior changes inside OpenClaw: channel delivery, provider/model routing, memory/search, session recovery, UI, and security-boundary fixes.
- Worth watching after deploy: OpenClaw startup, Discord/Telegram/WhatsApp delivery if enabled, provider/model auth resolution, memory/QMD search, and any generated-media or subagent workflows.

## Validation

- PR diff inspected: only `kubernetes/cluster/ai/openclaw/openclaw.yaml` changes.
- Upstream release notes pulled from `openclaw/openclaw` stable tags `v2026.6.5`, `v2026.6.6`, and `v2026.6.8`.

---

Original Renovate PR: image bump from `v2026.6.1.1` to `v2026.6.8.0`.
