### PR TITLE
[feature] Migrate OpenClaw config to 2026.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Infrastructure
 
-[![k8s](https://img.shields.io/badge/MicroK8s-v1.35.0-black?style=flat-square)](https://k8s.io/)
+[![k8s](https://img.shields.io/badge/MicroK8s-v1.35.5-black?style=flat-square)](https://k8s.io/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/maxim-mityutko/home-infra/main?style=flat-square)](https://github.com/maxim-mityutko/home-infra/commits/main)
 
 ## Notes

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -207,11 +207,6 @@
         "config": {
           "dreaming": {
             "enabled": true
-          },
-          "memoryPolicy": {
-            "excludeSessions": {
-              "chatTypes": ["group", "channel"]
-            }
           }
         },
         "enabled": true

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -77,6 +77,11 @@
     "entries": {
       "main": {
         "workspace": "~/.openclaw/workspace/bender",
+        "memory": {
+          "search": {
+            "rememberAcrossConversations": true
+          }
+        },
         "identity": {
           "name": "Bender"
         },
@@ -86,6 +91,11 @@
       },
       "fast": {
         "workspace": "~/.openclaw/workspace/clamps",
+        "memory": {
+          "search": {
+            "rememberAcrossConversations": true
+          }
+        },
         "identity": {
           "name": "Clamps"
         },
@@ -197,6 +207,11 @@
         "config": {
           "dreaming": {
             "enabled": true
+          },
+          "memoryPolicy": {
+            "excludeSessions": {
+              "chatTypes": ["group", "channel"]
+            }
           }
         },
         "enabled": true
@@ -218,9 +233,10 @@
       "memory-wiki": {
         "enabled": true,
         "config": {
-          "vaultMode": "isolated",
+          "vaultMode": "bridge",
           "vault": {
-            "path": "~/.openclaw/wiki/main",
+            "scope": "agent",
+            "path": "~/.openclaw/wiki",
             "renderMode": "obsidian"
           },
           "obsidian": {
@@ -230,7 +246,7 @@
             "openAfterWrites": false
           },
           "bridge": {
-            "enabled": false,
+            "enabled": true,
             "readMemoryArtifacts": true,
             "indexDreamReports": true,
             "indexDailyNotes": true,

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -409,6 +409,7 @@
   "channels": {
     "discord": {
       "enabled": true,
+      "defaultAccount": "bender",
       "commands": {
         "native": true
       },
@@ -448,8 +449,7 @@
               "users": ["${DISCORD_OWNER_ID}"]
             }
           }
-        },
-        "default": {"groupPolicy": "allowlist"}
+        }
       }
     },
     "whatsapp": {

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -18,8 +18,7 @@
       "enabled": true,
       "allowedOrigins": [
         "https://openclaw.brhd.io"
-      ],
-      "dangerouslyDisableDeviceAuth": true
+      ]
     }
   },
 
@@ -60,22 +59,24 @@
       "userTimezone": "Europe/Amsterdam",
       "thinkingDefault": "medium",
       "reasoningDefault": "off",
-      "memorySearch": {
-        "provider": "none"
-      },
       "model": {
         "primary": "openai/gpt-5.6-terra",
         "fallbacks": [
           "ollama/nemotron-3-super",
           "ollama/nemotron-3-ultra"
         ]
+      },
+      "heartbeat": {
+        "agentId": "main"
+      },
+      "systemAgent": {
+        "agentId": "main"
       }
     },
-    "list": [
-      {
-        "id": "main",
+    "ownership": "explicit",
+    "entries": {
+      "main": {
         "workspace": "~/.openclaw/workspace/bender",
-        "default": true,
         "identity": {
           "name": "Bender"
         },
@@ -83,8 +84,7 @@
           "mentionPatterns": ["@bender", "Bender"]
         }
       },
-      {
-        "id": "fast",
+      "fast": {
         "workspace": "~/.openclaw/workspace/clamps",
         "identity": {
           "name": "Clamps"
@@ -102,8 +102,7 @@
         "fastModeDefault": true,
         "thinkingDefault": "off"
       },
-      {
-        "id": "small",
+      "small": {
         "workspace": "~/.openclaw/workspace/tinny-tim",
         "identity": {
           "name": "Tinny Tim"
@@ -115,7 +114,7 @@
         "model": "ollama/gemini-3-flash-preview:cloud",
         "thinkingDefault": "off"
       }
-    ]
+    }
   },
 
   "bindings": [
@@ -132,17 +131,26 @@
         "channel": "discord",
         "accountId": "clamps"
       }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "discord",
+        "accountId": "*"
+      }
+    },
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "telegram",
+        "accountId": "*"
+      }
     }
   ],
 
   "cron": {
     "enabled": true,
-    "maxConcurrentRuns": 1,
-    "sessionRetention": "24h",
-    "runLog": {
-      "maxBytes": "5mb",
-      "keepLines": 10000
-    }
+    "sessionRetention": "24h"
   },
 
   "commands": {
@@ -256,9 +264,11 @@
       },
       "browser": {
         "enabled": true
+      },
+      "discord": {
+        "enabled": true
       }
-    },
-    "bundledDiscovery": "compat"
+    }
   },
   "skills": {
     "load": {
@@ -451,10 +461,10 @@
       "allowFrom": ["${TELEGRAM_OWNER_ID}"],
       "groupPolicy": "allowlist",
       "groupAllowFrom": ["${TELEGRAM_OWNER_ID}"],
-      "groups": { 
-        "*": { 
+      "groups": {
+        "*": {
           "requireMention": true
-        } 
+        }
       }
     },
     "slack": {
@@ -473,8 +483,7 @@
     "defaultProfile": "browserless",
     "profiles": {
       "browserless": {
-        "cdpUrl": "ws://browserless.ai.svc.cluster.local.:3000?token=${BROWSERLESS_API_KEY}&timeout=600000",
-        "color": "#4285F4"
+        "cdpUrl": "ws://browserless.ai.svc.cluster.local.:3000?token=${BROWSERLESS_API_KEY}&timeout=600000"
       }
     }
   },
@@ -500,7 +509,19 @@
   "logging": {
     "level": "info",
     "consoleLevel": "info",
-    "consoleStyle": "compact",
-    "redactSensitive": "tools"
+    "consoleStyle": "pretty"
+  },
+  "talk": {
+    "agentId": "main"
+  },
+  "memory": {
+    "search": {
+      "provider": "none"
+    }
+  },
+  "meta": {
+    "migrations": {
+      "modelPolicyAllowlist": true
+    }
   }
 }

--- a/kubernetes/cluster/ai/openclaw/config/openclaw.json
+++ b/kubernetes/cluster/ai/openclaw/config/openclaw.json
@@ -175,7 +175,7 @@
 
   "plugins": {
     "load": {
-      "paths": ["/app/custom/extensions"]
+      "paths": []
     },
     "allow": [
       "ollama",

--- a/kubernetes/cluster/ai/openclaw/openclaw.yaml
+++ b/kubernetes/cluster/ai/openclaw/openclaw.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: gateway
           # Using custom image with baked in dependencies
-          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.9.2.0
+          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.9.3.0
           command:
             - node
             - /app/dist/index.js

--- a/kubernetes/cluster/ai/openclaw/openclaw.yaml
+++ b/kubernetes/cluster/ai/openclaw/openclaw.yaml
@@ -92,7 +92,7 @@ spec:
       containers:
         - name: gateway
           # Using custom image with baked in dependencies
-          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.9.3.0
+          image: ghcr.io/maxim-mityutko/openclaw-docker:v2026.9.3.1
           command:
             - node
             - /app/dist/index.js


### PR DESCRIPTION
## Description

Migrates the OpenClaw gateway configuration and container image to the 2026.9.3 release format. The change converts agent configuration to explicit entries and ownership, enables durable cross-conversation memory search for `main` and `fast`, updates Discord routing defaults, and removes deprecated or incompatible settings.

It also updates the deployed OpenClaw image to `v2026.9.3.1` and the README MicroK8s badge to v1.35.5.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (maintenance, documentation improvement, version upgrade)

## Operational impact

The gateway will restart onto OpenClaw 2026.9.3.1. Device-auth bypass is removed, so clients must use the supported authentication flow. The new Discord wildcard bindings route unmatched Discord accounts to the main agent; verify that this is intended for every configured account before deployment.

## Validation

- Parsed `kubernetes/cluster/ai/openclaw/config/openclaw.json` from the exact PR head with `jq`.
- Ran `git diff --check` against `main`.
- Inspected the generated manifest change and confirmed the OpenClaw image is `ghcr.io/maxim-mityutko/openclaw-docker:v2026.9.3.1`.
- No CI checks are configured for this branch.

## Checklist
- [x] PR title follows naming standards: [feature|bugfix|chore] Short description of the change
- [ ] PR introduces a new service and requires updates to the README.md
- [ ] README.md is updated with the following:
  - [ ] service name
  - [ ] short description
  - [ ] repository link
  - [ ] documentation link
  - [ ] docker or helm link
  - [ ] docker or helm documentation
- [ ] `Homer` dashboard has been updated
